### PR TITLE
Implement a new console input system to fix an issue with the tmux send-keys command

### DIFF
--- a/MultiAdmin/Config/Config.cs
+++ b/MultiAdmin/Config/Config.cs
@@ -241,5 +241,22 @@ namespace MultiAdmin.Config
 
 			return def;
 		}
+
+		public ConsoleInputSystem GetConsoleInputSystem(string key, ConsoleInputSystem def = ConsoleInputSystem.New)
+		{
+			try
+			{
+				string value = GetString(key);
+
+				if (!string.IsNullOrEmpty(value) && Enum.TryParse<ConsoleInputSystem>(value, out var consoleInputSystem))
+					return consoleInputSystem;
+			}
+			catch (Exception e)
+			{
+				Program.LogDebugException(nameof(GetConsoleInputSystem), e);
+			}
+
+			return def;
+		}
 	}
 }

--- a/MultiAdmin/Config/Config.cs
+++ b/MultiAdmin/Config/Config.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using MultiAdmin.ConsoleTools;
+using MultiAdmin.ServerIO;
 using MultiAdmin.Utility;
 
 namespace MultiAdmin.Config
@@ -242,13 +243,13 @@ namespace MultiAdmin.Config
 			return def;
 		}
 
-		public ConsoleInputSystem GetConsoleInputSystem(string key, ConsoleInputSystem def = ConsoleInputSystem.New)
+		public InputHandler.ConsoleInputSystem GetConsoleInputSystem(string key, InputHandler.ConsoleInputSystem def = InputHandler.ConsoleInputSystem.New)
 		{
 			try
 			{
 				string value = GetString(key);
 
-				if (!string.IsNullOrEmpty(value) && Enum.TryParse<ConsoleInputSystem>(value, out var consoleInputSystem))
+				if (!string.IsNullOrEmpty(value) && Enum.TryParse<InputHandler.ConsoleInputSystem>(value, out var consoleInputSystem))
 					return consoleInputSystem;
 			}
 			catch (Exception e)

--- a/MultiAdmin/Config/MultiAdminConfig.cs
+++ b/MultiAdmin/Config/MultiAdminConfig.cs
@@ -50,9 +50,9 @@ namespace MultiAdmin.Config
 			new ConfigEntry<string[]>("multiadmin_debug_log_whitelist", new string[0],
 				"MultiAdmin Debug Logging Whitelist", "Which tags to log for MultiAdmin debug logging (Defaults to logging all if none are provided)");
 
-		public ConfigEntry<bool> UseNewInputSystem { get; } =
-			new ConfigEntry<bool>("use_new_input_system", true,
-				"Use New Input System", "Whether to use the new input system, if false, the original input system will be used");
+		public ConfigEntry<ConsoleInputSystem> ConsoleInputSystem { get; } =
+			new ConfigEntry<ConsoleInputSystem>("console_input_system", MultiAdmin.ConsoleInputSystem.New,
+				"Console Input System", "Which console input system to use");
 
 		public ConfigEntry<bool> HideInput { get; } =
 			new ConfigEntry<bool>("hide_input", false,
@@ -296,6 +296,12 @@ namespace MultiAdmin.Config
 				case ConfigEntry<bool> config:
 				{
 					config.Value = Config.GetBool(config.Key, config.Default);
+					break;
+				}
+
+				case ConfigEntry<ConsoleInputSystem> config:
+				{
+					config.Value = Config.GetConsoleInputSystem(config.Key, config.Default);
 					break;
 				}
 

--- a/MultiAdmin/Config/MultiAdminConfig.cs
+++ b/MultiAdmin/Config/MultiAdminConfig.cs
@@ -50,8 +50,12 @@ namespace MultiAdmin.Config
 			new ConfigEntry<string[]>("multiadmin_debug_log_whitelist", new string[0],
 				"MultiAdmin Debug Logging Whitelist", "Which tags to log for MultiAdmin debug logging (Defaults to logging all if none are provided)");
 
-		public ConfigEntry<ConsoleInputSystem> ConsoleInputSystem { get; } =
-			new ConfigEntry<ConsoleInputSystem>("console_input_system", MultiAdmin.ConsoleInputSystem.New,
+		public ConfigEntry<bool> UseNewInputSystem { get; } =
+			new ConfigEntry<bool>("use_new_input_system", true,
+				"Use New Input System", "**OBSOLETE: Use `console_input_system` instead, this config option may be removed in a future version of MultiAdmin.** Whether to use the new input system, if false, the original input system will be used");
+
+		public ConfigEntry<InputHandler.ConsoleInputSystem> ConsoleInputSystem { get; } =
+			new ConfigEntry<InputHandler.ConsoleInputSystem>("console_input_system", InputHandler.ConsoleInputSystem.New,
 				"Console Input System", "Which console input system to use");
 
 		public ConfigEntry<bool> HideInput { get; } =
@@ -171,6 +175,26 @@ namespace MultiAdmin.Config
 				"Start Config on Full", "Start server with this config folder once the server becomes full [Requires Modding]");
 
 		#endregion
+
+		public InputHandler.ConsoleInputSystem ActualConsoleInputSystem
+		{
+			get
+			{
+				if (UseNewInputSystem.Value)
+				{
+					switch (ConsoleInputSystem.Value)
+					{
+						case InputHandler.ConsoleInputSystem.New:
+							return HideInput.Value ? InputHandler.ConsoleInputSystem.Old : InputHandler.ConsoleInputSystem.New;
+
+						case InputHandler.ConsoleInputSystem.Old:
+							return InputHandler.ConsoleInputSystem.Old;
+					}
+				}
+
+				return InputHandler.ConsoleInputSystem.Original;
+			}
+		}
 
 		public const string ConfigFileName = "scp_multiadmin.cfg";
 		public static readonly string GlobalConfigFilePath = Utils.GetFullPathSafe(ConfigFileName);
@@ -299,7 +323,7 @@ namespace MultiAdmin.Config
 					break;
 				}
 
-				case ConfigEntry<ConsoleInputSystem> config:
+				case ConfigEntry<InputHandler.ConsoleInputSystem> config:
 				{
 					config.Value = Config.GetConsoleInputSystem(config.Key, config.Default);
 					break;

--- a/MultiAdmin/Features/GithubGenerator.cs
+++ b/MultiAdmin/Features/GithubGenerator.cs
@@ -122,6 +122,12 @@ namespace MultiAdmin.Features
 						break;
 					}
 
+					case ConfigEntry<ConsoleInputSystem> config:
+					{
+							stringBuilder.Append($"ConsoleInputSystem{ColumnSeparator}{config.Default}");
+							break;
+					}
+
 					default:
 					{
 						stringBuilder.Append(

--- a/MultiAdmin/Features/GithubGenerator.cs
+++ b/MultiAdmin/Features/GithubGenerator.cs
@@ -4,6 +4,7 @@ using System.Text;
 using MultiAdmin.Config;
 using MultiAdmin.Config.ConfigHandler;
 using MultiAdmin.Features.Attributes;
+using MultiAdmin.ServerIO;
 using MultiAdmin.Utility;
 
 namespace MultiAdmin.Features
@@ -122,7 +123,7 @@ namespace MultiAdmin.Features
 						break;
 					}
 
-					case ConfigEntry<ConsoleInputSystem> config:
+					case ConfigEntry<InputHandler.ConsoleInputSystem> config:
 					{
 							stringBuilder.Append($"ConsoleInputSystem{ColumnSeparator}{config.Default}");
 							break;

--- a/MultiAdmin/Program.cs
+++ b/MultiAdmin/Program.cs
@@ -81,7 +81,7 @@ namespace MultiAdmin
 				if (Headless) return;
 
 				new ColoredMessage(Utils.TimeStampMessage(message), color).WriteLine((!MultiAdminConfig.GlobalConfig?.HideInput?.Value ?? false) &&
-					(MultiAdminConfig.GlobalConfig?.UseNewInputSystem?.Value ?? false));
+					(MultiAdminConfig.GlobalConfig?.ConsoleInputSystem.Value.IsNewInputSystem() ?? false));
 			}
 		}
 

--- a/MultiAdmin/Program.cs
+++ b/MultiAdmin/Program.cs
@@ -80,8 +80,7 @@ namespace MultiAdmin
 			{
 				if (Headless) return;
 
-				new ColoredMessage(Utils.TimeStampMessage(message), color).WriteLine((!MultiAdminConfig.GlobalConfig?.HideInput?.Value ?? false) &&
-					(MultiAdminConfig.GlobalConfig?.ConsoleInputSystem.Value.IsNewInputSystem() ?? false));
+				new ColoredMessage(Utils.TimeStampMessage(message), color).WriteLine(MultiAdminConfig.GlobalConfig?.ActualConsoleInputSystem == InputHandler.ConsoleInputSystem.New);
 			}
 		}
 

--- a/MultiAdmin/Server.cs
+++ b/MultiAdmin/Server.cs
@@ -388,8 +388,8 @@ namespace MultiAdmin
 
 					Write($"Starting server with the following parameters:\n{scpslExe} {startInfo.Arguments}");
 
-					if (ServerConfig.ConsoleInputSystem.Value.IsOriginalInputSystem())
-						Write("You are using the original input system. It may prevent MultiAdmin from closing and cause ghost game processes.", ConsoleColor.Red);
+					if (ServerConfig.ActualConsoleInputSystem == InputHandler.ConsoleInputSystem.Original)
+						Write("You are using the original input system. It may prevent MultiAdmin from closing and/or cause ghost game processes", ConsoleColor.Red);
 
 					// Reset the supported mod features
 					supportedModFeatures = ModFeatures.None;
@@ -653,10 +653,10 @@ namespace MultiAdmin
 
 				ColoredMessage[] timeStampedMessage = Utils.TimeStampMessage(messages, timeStampColor);
 
-				timeStampedMessage.WriteLine(!ServerConfig.HideInput.Value && ServerConfig.ConsoleInputSystem.Value.IsNewInputSystem());
+				timeStampedMessage.WriteLine(ServerConfig.ActualConsoleInputSystem == InputHandler.ConsoleInputSystem.New);
 
-				if (!ServerConfig.HideInput.Value && ServerConfig.ConsoleInputSystem.Value.IsNewInputSystem())
-					InputHandler.WriteInputAndSetCursor(ServerConfig);
+				if (ServerConfig.ActualConsoleInputSystem == InputHandler.ConsoleInputSystem.New)
+					InputHandler.WriteInputAndSetCursor(true);
 			}
 		}
 
@@ -762,16 +762,5 @@ namespace MultiAdmin
 		ExitActionRestart,
 		Stopped,
 		StoppedUnexpectedly
-	}
-
-	public enum ConsoleInputSystem
-	{
-		// Represents the default input system, which calls Console.ReadLine and blocks the calling context
-		Original,
-		// Represents the "old" input system, which calls non-blocking methods
-		Old,
-		// Represents the "new" input system, which also calls non-blocking methods,
-		// but the main difference is great display
-		New,
 	}
 }

--- a/MultiAdmin/Server.cs
+++ b/MultiAdmin/Server.cs
@@ -388,7 +388,7 @@ namespace MultiAdmin
 
 					Write($"Starting server with the following parameters:\n{scpslExe} {startInfo.Arguments}");
 
-					if (ServerConfig.ConsoleInputSystem.Value.IsOriginInputSystem())
+					if (ServerConfig.ConsoleInputSystem.Value.IsOriginalInputSystem())
 						Write("You are using the original input system. It may prevent MultiAdmin from closing and cause ghost game processes.", ConsoleColor.Red);
 
 					// Reset the supported mod features

--- a/MultiAdmin/Server.cs
+++ b/MultiAdmin/Server.cs
@@ -388,6 +388,9 @@ namespace MultiAdmin
 
 					Write($"Starting server with the following parameters:\n{scpslExe} {startInfo.Arguments}");
 
+					if (ServerConfig.ConsoleInputSystem.Value.IsOriginInputSystem())
+						Write("You are using the original input system. It may prevent MultiAdmin from closing and cause ghost game processes.", ConsoleColor.Red);
+
 					// Reset the supported mod features
 					supportedModFeatures = ModFeatures.None;
 

--- a/MultiAdmin/Server.cs
+++ b/MultiAdmin/Server.cs
@@ -650,9 +650,9 @@ namespace MultiAdmin
 
 				ColoredMessage[] timeStampedMessage = Utils.TimeStampMessage(messages, timeStampColor);
 
-				timeStampedMessage.WriteLine(!ServerConfig.HideInput.Value && ServerConfig.UseNewInputSystem.Value);
+				timeStampedMessage.WriteLine(!ServerConfig.HideInput.Value && ServerConfig.ConsoleInputSystem.Value.IsNewInputSystem());
 
-				if (!ServerConfig.HideInput.Value && ServerConfig.UseNewInputSystem.Value)
+				if (!ServerConfig.HideInput.Value && ServerConfig.ConsoleInputSystem.Value.IsNewInputSystem())
 					InputHandler.WriteInputAndSetCursor(ServerConfig);
 			}
 		}
@@ -759,5 +759,16 @@ namespace MultiAdmin
 		ExitActionRestart,
 		Stopped,
 		StoppedUnexpectedly
+	}
+
+	public enum ConsoleInputSystem
+	{
+		// Represents the default input system, which calls Console.ReadLine and blocks the calling context
+		Original,
+		// Represents the "old" input system, which calls non-blocking methods
+		Old,
+		// Represents the "new" input system, which also calls non-blocking methods,
+		// but the main difference is great display
+		New,
 	}
 }

--- a/MultiAdmin/ServerIO/InputHandler.cs
+++ b/MultiAdmin/ServerIO/InputHandler.cs
@@ -114,7 +114,7 @@ namespace MultiAdmin.ServerIO
 			StringBuilder message = new StringBuilder();
 			while (true)
 			{
-				await WaitForKey(cancellationToken);
+				//await WaitForKey(cancellationToken);
 
 				ConsoleKeyInfo key = Console.ReadKey(server.ServerConfig.HideInput.Value);
 
@@ -151,7 +151,7 @@ namespace MultiAdmin.ServerIO
 			{
 				#region Key Press Handling
 
-				await WaitForKey(cancellationToken);
+				//await WaitForKey(cancellationToken);
 
 				ConsoleKeyInfo key = Console.ReadKey(true);
 

--- a/MultiAdmin/ServerIO/InputHandler.cs
+++ b/MultiAdmin/ServerIO/InputHandler.cs
@@ -61,13 +61,17 @@ namespace MultiAdmin.ServerIO
 					}
 
 					string message;
-					if (!server.ServerConfig.HideInput.Value && server.ServerConfig.UseNewInputSystem.Value && SectionBufferWidth - TotalIndicatorLength > 0)
+					if (!server.ServerConfig.HideInput.Value && server.ServerConfig.ConsoleInputSystem.Value.IsNewInputSystem() && SectionBufferWidth - TotalIndicatorLength > 0)
 					{
 						message = await GetInputLineNew(server, cancellationToken, prevMessages);
 					}
-					else
+					else if (server.ServerConfig.ConsoleInputSystem.Value.IsOldInputSystem())
 					{
 						message = await GetInputLineOld(server, cancellationToken);
+					}
+					else
+					{
+						message = Console.ReadLine();
 					}
 
 					if (string.IsNullOrEmpty(message)) continue;
@@ -114,7 +118,7 @@ namespace MultiAdmin.ServerIO
 			StringBuilder message = new StringBuilder();
 			while (true)
 			{
-				//await WaitForKey(cancellationToken);
+				await WaitForKey(cancellationToken);
 
 				ConsoleKeyInfo key = Console.ReadKey(server.ServerConfig.HideInput.Value);
 
@@ -151,7 +155,7 @@ namespace MultiAdmin.ServerIO
 			{
 				#region Key Press Handling
 
-				//await WaitForKey(cancellationToken);
+				await WaitForKey(cancellationToken);
 
 				ConsoleKeyInfo key = Console.ReadKey(true);
 
@@ -407,7 +411,7 @@ namespace MultiAdmin.ServerIO
 				if (Program.Headless) return;
 
 				MultiAdminConfig curConfig = config ?? MultiAdminConfig.GlobalConfig;
-				message?.Write(!curConfig.HideInput.Value && curConfig.UseNewInputSystem.Value);
+				message?.Write(!curConfig.HideInput.Value && curConfig.ConsoleInputSystem.Value.IsNewInputSystem());
 
 				CurrentInput = message;
 			}

--- a/MultiAdmin/Utility/Utils.cs
+++ b/MultiAdmin/Utility/Utils.cs
@@ -256,6 +256,6 @@ namespace MultiAdmin.Utility
 
 		public static bool IsNewInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.New;
 		public static bool IsOldInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.Old;
-		public static bool IsOriginInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.Original;
+		public static bool IsOriginalInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.Original;
 	}
 }

--- a/MultiAdmin/Utility/Utils.cs
+++ b/MultiAdmin/Utility/Utils.cs
@@ -253,9 +253,5 @@ namespace MultiAdmin.Utility
 			// If the versions are perfectly identical, return 0
 			return 0;
 		}
-
-		public static bool IsNewInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.New;
-		public static bool IsOldInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.Old;
-		public static bool IsOriginalInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.Original;
 	}
 }

--- a/MultiAdmin/Utility/Utils.cs
+++ b/MultiAdmin/Utility/Utils.cs
@@ -253,5 +253,9 @@ namespace MultiAdmin.Utility
 			// If the versions are perfectly identical, return 0
 			return 0;
 		}
+
+		public static bool IsNewInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.New;
+		public static bool IsOldInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.Old;
+		public static bool IsOriginInputSystem(this ConsoleInputSystem consoleInputSystem) => consoleInputSystem == ConsoleInputSystem.Original;
 	}
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Make sure that you are running Mono 5.18.0 or higher, otherwise you might have i
 4. Optional: Create a file named `scp_multiadmin.cfg` within your server's folder for configuring MultiAdmin specifically for that server
 
 ## Features
+
 - Config Generator: Generates a full default MultiAdmin config file
 - Config Reload: Reloads the MultiAdmin configuration file
 - Exit Command: Adds a graceful exit command
@@ -71,7 +72,8 @@ multiadmin_nolog | Boolean | False | Disable logging to file
 multiadmin_debug_log | Boolean | True | Enables MultiAdmin debug logging, this logs to a separate file than any other logs
 multiadmin_debug_log_blacklist | String List | HandleMessage, StringMatches, MessageListener | Which tags to block for MultiAdmin debug logging
 multiadmin_debug_log_whitelist | String List | **Empty** | Which tags to log for MultiAdmin debug logging (Defaults to logging all if none are provided)
-console_input_system | [ConsoleInputSystem](#ConsoleInputSystem) | New | Which console input system to use
+use_new_input_system | Boolean | True | **OBSOLETE: Use `console_input_system` instead, this config option may be removed in a future version of MultiAdmin.** Whether to use the new input system, if false, the original input system will be used
+console_input_system | ConsoleInputSystem | New | Which console input system to use
 hide_input | Boolean | False | Whether to hide console input, if true, typed input will not be printed
 port | Unsigned Integer | 7777 | The port for the server to use
 copy_from_folder_on_reload | String | **Empty** | The location of a folder to copy files from into the folder defined by `config_location` whenever the configuration file is reloaded
@@ -102,12 +104,11 @@ servers_folder | String | servers | The location of the `servers` folder for Mul
 set_title_bar | Boolean | True | Whether to set the console window's titlebar, if false, this feature won't be used
 start_config_on_full | String | **Empty** | Start server with this config folder once the server becomes full [Requires Modding]
 
-
 ## ConsoleInputSystem
 If you are running into issues with the `tmux send-keys` command, switch to the original input system.
 
-String value | Intenger value | Description
+String String | Integer Value | Description
 --- | :---: | :----:
-Original | 0 | Represents the original input system. It may prevent MultiAdmin from closing and cause ghost game processes
-Old | 1 | Represents the old input system
-New | 2 | Represents the new input system. The main difference from the original input system is great display
+Original | 0 | Represents the original input system. It may prevent MultiAdmin from closing and/or cause ghost game processes.
+Old | 1 | Represents the old input system. This input system should operate similarly to the original input system but won't cause issues with MultiAdmin's functionality.
+New | 2 | Represents the new input system. The main difference from the original input system is an improved display.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ start_config_on_full | String | **Empty** | Start server with this config folder
 ## ConsoleInputSystem
 If you are running into issues with the `tmux send-keys` command, switch to the original input system.
 
-String String | Integer Value | Description
+String Value | Integer Value | Description
 --- | :---: | :----:
 Original | 0 | Represents the original input system. It may prevent MultiAdmin from closing and/or cause ghost game processes.
 Old | 1 | Represents the old input system. This input system should operate similarly to the original input system but won't cause issues with MultiAdmin's functionality.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ multiadmin_nolog | Boolean | False | Disable logging to file
 multiadmin_debug_log | Boolean | True | Enables MultiAdmin debug logging, this logs to a separate file than any other logs
 multiadmin_debug_log_blacklist | String List | HandleMessage, StringMatches, MessageListener | Which tags to block for MultiAdmin debug logging
 multiadmin_debug_log_whitelist | String List | **Empty** | Which tags to log for MultiAdmin debug logging (Defaults to logging all if none are provided)
-use_new_input_system | Boolean | True | Whether to use the new input system, if false, the original input system will be used
+console_input_system | [ConsoleInputSystem](#ConsoleInputSystem) | New | Which console input system to use
 hide_input | Boolean | False | Whether to hide console input, if true, typed input will not be printed
 port | Unsigned Integer | 7777 | The port for the server to use
 copy_from_folder_on_reload | String | **Empty** | The location of a folder to copy files from into the folder defined by `config_location` whenever the configuration file is reloaded
@@ -101,3 +101,13 @@ multiadmin_tick_delay | Integer | 1000 | The time in milliseconds between MultiA
 servers_folder | String | servers | The location of the `servers` folder for MultiAdmin to load multiple server configurations from
 set_title_bar | Boolean | True | Whether to set the console window's titlebar, if false, this feature won't be used
 start_config_on_full | String | **Empty** | Start server with this config folder once the server becomes full [Requires Modding]
+
+
+## ConsoleInputSystem
+If you are running into issues with the `tmux send-keys` command, switch to the original input system.
+
+String value | Intenger value | Description
+--- | :---: | :----:
+Original | 0 | Represents the original input system. It may prevent MultiAdmin from closing and cause ghost game processes
+Old | 1 | Represents the old input system
+New | 2 | Represents the new input system. The main difference from the original input system is great display


### PR DESCRIPTION
When you send some message to a tmux session, which runs MA, it reads the first key of the message and then falls in a loop with `Console.KeyAvailable`.
Somehow `Console.KeyAvailable` returns `false` after the first key is read, this part of code causes the issue https://github.com/ServerMod/MultiAdmin/blob/a64eec381d01cf02c94eabccca30f5d4606d400a/MultiAdmin/ServerIO/InputHandler.cs#L106-L109

My fix is to just remove all calls to `WaitForKey(CancellationToken)`, however, `Console.ReadKey()` always works and it blocks the task of reading input, are those `CancellationTokenSource`s needed at all?

Related to #252.

This PR implements a new console input system and removes the `use_new_input_system` config entry.
The default value of the new `console_input_system` config entry is `New` (as before).